### PR TITLE
Major rewrite for the offical JS client v0.2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
+    "editor.detectIndentation": true,
     "typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "dependencies": {
-        "backend.ai-client": "^0.1.4",
+        "backend.ai-client": "^0.2.0",
         "punycode": "^2.1.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -94,8 +94,8 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "dependencies": {
-        "punycode": "^2.1.0",
-        "backend.ai-client": "^0.1.4"
+        "backend.ai-client": "^0.1.4",
+        "punycode": "^2.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.32",

--- a/src/live-code-runner-view.ts
+++ b/src/live-code-runner-view.ts
@@ -39,6 +39,33 @@ export class LiveCodeRunnerView {
         return this.console_log.show();
     }
 
+    addOutput(consoleItems) {
+        let html: string = '';
+        for (let c of Array.from(consoleItems)) {
+            switch (c[0]) {
+            case 'stdout':
+                html += `<span class="live-console stdout">${this.escapeHtml(c[1])}</span>`;
+                break;
+            case 'stderr':
+                html += `<span class="live-console stderr">${this.escapeHtml(c[1])}</span>`;
+                break;
+            case 'media':
+                switch (c[1][0]) {
+                case 'image/svg+xml':
+                    html += c[1][1];
+                    break;
+                default:
+                    // pass
+                }
+                break;
+            default:
+                // pass
+            }
+        }
+        this.addHtmlContent(html);
+        return html != '';
+    }
+
     addHtmlContent(content) {
         this.provider.appendContent(content);
     	return this.provider.update(this.previewUri);
@@ -51,6 +78,12 @@ export class LiveCodeRunnerView {
 
     showResultPanel(){
         return vscode.commands.executeCommand('vscode.previewHtml', this.previewUri, vscode.ViewColumn.Two, 'RESULT');
+    }
+
+    private escapeHtml(text) {
+        return text.replace(/[\"&<>]/g, function (a) {
+        return { '"': '&quot;', '&': '&amp;', '<': '&lt;', '>': '&gt;' }[a];
+        });
     }
 }
 


### PR DESCRIPTION
 * More cleanly separate view-specific logic and extension main logic.
 * Reduce duplicate codes by using the new client library's API.
 * Apply ES6 enhancements more aggressively.
 * Use `switch` statements where possible.
 * Fix a wrong continuation status upon 'build-finished' (#10)
 * Attach VSCode/plugin versions to the `User-Agent` string using the new client API